### PR TITLE
Fix: Prevent overlapping toast notifications

### DIFF
--- a/presentation_layer/frontend/static/css/style.css
+++ b/presentation_layer/frontend/static/css/style.css
@@ -312,29 +312,6 @@ canvas {
     font-size: 0.9em;
 }
 
-/* Toast Notifications Styles */
-.toast-notification {
-    position: fixed;
-    bottom: 20px; 
-    right: 20px;
-    background-color: #333;
-    color: white;
-    padding: 15px 20px;
-    border-radius: 5px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
-    z-index: 10000;
-    opacity: 0;
-    transition: opacity 0.5s, transform 0.5s;
-    transform: translateY(20px); 
-}
-.toast-notification.show {
-    opacity: 1;
-    transform: translateY(0);
-}
-.toast-notification.success { background-color: #28a745; }
-.toast-notification.error { background-color: #dc3545; }
-.toast-notification.info { background-color: #17a2b8; }
-
 /* CSS for hidden rows in expenses table */
 .hidden-row {
     opacity: 0.5;

--- a/presentation_layer/frontend/static/js/ui_helpers.js
+++ b/presentation_layer/frontend/static/js/ui_helpers.js
@@ -39,13 +39,30 @@ function hideGlobalLoader() {
 }
 
 function showToast(message, type = 'info', duration = 3000) {
-    const toastContainer = document.body; 
+    let toastContainer = document.getElementById('toast-container');
+
+    if (!toastContainer) {
+        toastContainer = document.querySelector('.toast-container');
+    }
+
+    if (!toastContainer) {
+        toastContainer = document.createElement('div');
+        toastContainer.id = 'toast-container';
+        // The class 'toast-container' is also added for styling consistency,
+        // though the ID is primary for lookup.
+        toastContainer.className = 'toast-container';
+        document.body.appendChild(toastContainer);
+    }
+
     const toast = document.createElement('div');
-    toast.className = `toast-notification ${type}`; 
+    // Ensure the base class 'toast' is present, then the type-specific class.
+    toast.className = `toast toast-${type}`;
     toast.textContent = message;
     
     toastContainer.appendChild(toast);
 
+    // Delay adding 'show' class to allow CSS transition to take effect.
+    // Using a double requestAnimationFrame or a short timeout.
     requestAnimationFrame(() => {
         requestAnimationFrame(() => { 
             toast.classList.add('show');
@@ -55,11 +72,18 @@ function showToast(message, type = 'info', duration = 3000) {
     if (duration > 0) {
         setTimeout(() => {
             toast.classList.remove('show');
+            // Wait for the hide transition to complete before removing the element.
             toast.addEventListener('transitionend', () => {
+                // Check if the toast is still a child of the container before removing
                 if (toast.parentNode === toastContainer) {
                     toastContainer.removeChild(toast);
                 }
-            }, { once: true }); 
+                // If the container is empty after removing a toast, it could be removed.
+                // However, standard behavior is to keep the container.
+                // if (toastContainer.children.length === 0) {
+                //     toastContainer.remove(); // Optional: remove container if empty
+                // }
+            }, { once: true }); // Ensure the event listener is removed after firing.
         }, duration);
     }
 }


### PR DESCRIPTION
I updated the showToast function in ui_helpers.js to use a centralized toast container. This ensures that multiple notifications are displayed in a stacked, vertical manner rather than overlapping at a fixed position.

I also removed the old .toast-notification CSS rules from style.css as they are no longer needed after the JavaScript update. The system now uses .toast-container and .toast for styling notifications.